### PR TITLE
Make the docs more specific

### DIFF
--- a/content/patterns/API/filepond-instance.md
+++ b/content/patterns/API/filepond-instance.md
@@ -223,7 +223,7 @@ pond.addFiles('./my-file.jpg', './my-documents.zip', { index: 0 });
 pond.addFiles(['./my-file.jpg', './my-documents.zip'], { index: 0 });
 ```
 
-As state earlier the `addFile` method also accepts Blobs, File objects and DataURLs.
+As stated earlier the `addFile` method also accepts Blobs, File objects and DataURLs.
 
 ```js
 // Adding a basic DataURL
@@ -258,7 +258,7 @@ pond
 
 We can trigger manual processing of files using the `processFile` method.
 
-Files can be removed by `id`, `index` or `file`. A parameter is not required.
+Files can be processed by `id`, `index` or `file`. A parameter is not required.
 
 ```js
 // processes the first file

--- a/content/patterns/API/filepond-object.md
+++ b/content/patterns/API/filepond-object.md
@@ -292,6 +292,7 @@ FilePond.registerPlugin(
     FilePondPluginImagePreview,
     FilePondPluginFileValidateSize
 );
+// create a FilePond instance here
 ```
 
 A plugin will fire a `FilePond:pluginloaded` event on the document when it's ready for use. The event `detail` property will contain the plugin.

--- a/content/patterns/API/filepond-object.md
+++ b/content/patterns/API/filepond-object.md
@@ -292,8 +292,11 @@ FilePond.registerPlugin(
     FilePondPluginImagePreview,
     FilePondPluginFileValidateSize
 );
-// create a FilePond instance here
 ```
+
+{{% note %}}
+Plugins need to be registered before we create our first FilePond instance.
+{{% /note %}}
 
 A plugin will fire a `FilePond:pluginloaded` event on the document when it's ready for use. The event `detail` property will contain the plugin.
 
@@ -302,7 +305,3 @@ document.addEventListener('FilePond:pluginloaded', e => {
     console.log('FilePond plugin is ready for use', e.detail);
 });
 ```
-
-{{% note %}}
-Plugins need to be registered before we create our first FilePond instance.
-{{% /note %}}

--- a/content/patterns/API/server.md
+++ b/content/patterns/API/server.md
@@ -216,7 +216,7 @@ Note that in the examples below we make use of [arrow functions](https://develop
 
 ### Process
 
-Custom `process` function receives a `file` object plus a set of FilePond callback methods to return control to FilePond. The `file` parameter contains the native file object and access to it is restricted in the `process` function to prevent setting properties or running functions that would would contradict or interfere with the current processing of the file.
+The custom `process` function receives a `file` object plus a set of FilePond callback methods to return control to FilePond. The `file` parameter contains the native file object (instead of a FilePond file item) access the file item is restricted in the `process` function to prevent setting properties or running functions that would would contradict or interfere with the current processing of the file.
 
 ```js
 const handler = (fieldName, file, metadata, load, error, progress, abort) => {
@@ -227,9 +227,9 @@ const handler = (fieldName, file, metadata, load, error, progress, abort) => {
     error('oh my goodness');
 
     // Should call the progress method to update the progress to 100% before calling load
+    // Setting computable to false switches the loading indicator to infinite mode
     // (computable, processedSize, totalSize)
     progress(true, 0, 1024);
-    // progress(false) switches the loading indicator to infinite mode
 
 
     // Should call the load method when done and pass the returned server file id


### PR DESCRIPTION
By differentiating between what the client (browser or user) does and what Filepond does, it becomes easier to understand the upload, revert, load and fetch processes. 